### PR TITLE
Fix compression for Ubuntu Jammy

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,3 +9,6 @@ DEBVERSION := $(VERSION)-0~$(DISTRIBUTION)0
 
 override_dh_gencontrol:
 	dh_gencontrol -- -v$(DEBVERSION)
+
+override_dh_builddeb:
+		dh_builddeb -- -Zxz


### PR DESCRIPTION
We still need this for the Quanta hypervisors still running within the fleet. Let's fix the compression for Ubuntu Jammy.

[sc-52765]